### PR TITLE
feature: support agp 8.13.0

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath 'com.android.tools.build:gradle:8.13.0'
         classpath 'com.github.kezong:fat-aar:1.3.8'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22"
     }

--- a/example/gradle/wrapper/gradle-wrapper.properties
+++ b/example/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 22 12:01:47 CEST 2018
+#Fri Sep 19 18:48:55 CST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip

--- a/source/build.gradle
+++ b/source/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'groovy'
+apply plugin: 'java'
 apply from: "./upload.gradle"
 
 buildscript {
@@ -18,7 +19,7 @@ dependencies {
     implementation gradleApi()
     implementation localGroovy()
     implementation "org.javassist:javassist:3.27.0-GA"
-    implementation 'com.android.tools.build:gradle:8.2.2'
+    implementation 'com.android.tools.build:gradle:8.13.0'
     implementation 'com.android.tools:common:31.8.2'
     implementation 'org.ow2.asm:asm-commons:9.7'
 }

--- a/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
@@ -2,6 +2,7 @@ package com.kezong.fataar
 
 import com.android.build.gradle.api.LibraryVariant
 import com.android.build.gradle.tasks.ManifestProcessorTask
+import com.android.manifmerger.ManifestMerger2
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.ResolvedArtifact
@@ -257,6 +258,9 @@ final class VariantProcessor {
 
         TaskProvider<LibraryManifestMerger> manifestsMergeTask = mProject
                 .tasks.register("merge${mVariant.name.capitalize()}Manifest", LibraryManifestMerger) {
+            if (FatUtils.compareVersion(VersionAdapter.AGPVersion, "8.13.0") >= 0) {
+                withMergerFeatures(ManifestMerger2.Invoker.Feature.USES_SDK_IN_MANIFEST_LENIENT_HANDLING)
+            }
             setGradleVersion(mProject.getGradle().getGradleVersion())
             setGradlePluginVersion(VersionAdapter.AGPVersion)
             setMainManifestFile(manifestOutput)

--- a/source/src/main/java/com/kezong/fataar/LibraryManifestMerger.java
+++ b/source/src/main/java/com/kezong/fataar/LibraryManifestMerger.java
@@ -27,6 +27,7 @@ public class LibraryManifestMerger extends DefaultTask {
     private String mGradlePluginVersion;
 
     private String mGradleVersion;
+    private ManifestMerger2.Invoker.Feature[] mMergerFeatures;
 
     private File mMainManifestFile;
 
@@ -40,6 +41,10 @@ public class LibraryManifestMerger extends DefaultTask {
 
     public void setGradleVersion(String gradleVersion) {
         mGradleVersion = gradleVersion;
+    }
+
+    public void withMergerFeatures(ManifestMerger2.Invoker.Feature... features) {
+        mMergerFeatures = features;
     }
 
     protected void doTaskAction() {
@@ -78,6 +83,9 @@ public class LibraryManifestMerger extends DefaultTask {
             }
         }
         mergerInvoker.addManifestProviders(manifestProviders);
+        if (mMergerFeatures != null) {
+            mergerInvoker.withFeatures(mMergerFeatures);
+        }
         MergingReport mergingReport = mergerInvoker.merge();
         if (mergingReport.getResult().isError()) {
             getLogger().error(mergingReport.getReportString());


### PR DESCRIPTION
Fix the error on AGP 8.13.0:
> * What went wrong:
> Execution failed for task ':library:processReleaseManifest'.
> \> Manifest merger failed : The <uses-sdk> element was found in your AndroidManifest.xml file. Starting with Android Gradle Plugin 9.0, this is a build-breaking error. Previously, this condition only generated a warning. However, the SDK version properties defined in the DSL or the variant API have always overridden the manifest values. To eliminate this source of confusion, declaring <uses-sdk> in the manifest is no longer allowed.
>  
>   Fix: Remove <uses-sdk> from your AndroidManifest.xml
