### PR TITLE
fix: build error on AGP 8.13

### DIFF
--- a/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
@@ -139,13 +139,20 @@ final class VariantProcessor {
 
     private void processDeepLinkTasks() {
         String taskName = "extractDeepLinksForAar${mVariant.name.capitalize()}"
-        TaskProvider extractDeepLinks = mProject.tasks.named(taskName)
-        if (extractDeepLinks == null) {
+        TaskProvider extractDeepLinksForAar = mProject.tasks.named(taskName)
+        if (extractDeepLinksForAar == null) {
             throw new RuntimeException("Can not find task ${taskName}!")
         }
 
-        extractDeepLinks.configure {
+        extractDeepLinksForAar.configure {
             dependsOn(mExplodeTasks)
+        }
+
+        TaskProvider extractDeepLinks = mProject.tasks.named("extractDeepLinks${mVariant.name.capitalize()}")
+        if (extractDeepLinks != null) {
+            extractDeepLinks.configure {
+                dependsOn(mExplodeTasks)
+            }
         }
     }
 


### PR DESCRIPTION
Fix the error on AGP 8.13.0 when trying to build the App:

What went wrong:
> org.gradle.internal.execution.WorkValidationException: A problem was found with the configuration of task ':test-module:extractDeepLinksDebug' (type 'ExtractDeepLinksTask').
>  \- Gradle detected a problem with the following location: '/Users/xxx/test-project/test-module/build/intermediates/exploded-aar/Test.test-module/test-sdk/unspecified/debug/res/navigation'.
>    
>    Reason: Task ':test-module:extractDeepLinksDebug' uses this output of task ':test-module:explodeTest.test-moduleTest-sdk-3.8.1Debug' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
>    
>    Possible solutions:
>      1. Declare task ':test-module:explodeTest.test-moduleTest-sdk-3.8.1Debug' as an input of ':test-module:extractDeepLinksDebug'.
>      2. Declare an explicit dependency on ':test-module:explodeTest.test-moduleTest-sdk-3.8.1Debug' from ':test-module:extractDeepLinksDebug' using Task#dependsOn.
>      3. Declare an explicit dependency on ':test-module:explodeTest.test-moduleTest-sdk-3.8.1Debug' from ':test-module:extractDeepLinksDebug' using Task#mustRunAfter.